### PR TITLE
Use RTX - Real-Time in Google examples

### DIFF
--- a/examples/Google3DTiles/NewYork.usda
+++ b/examples/Google3DTiles/NewYork.usda
@@ -68,7 +68,6 @@
             float3 "rtx:post:tonemap:whitepoint" = (1, 1, 1)
             float3 "rtx:raytracing:inscattering:singleScatteringAlbedo" = (0.9, 0.9, 0.9)
             float3 "rtx:raytracing:inscattering:transmittanceColor" = (0.5, 0.5, 0.5)
-            string "rtx:rendermode" = "PathTracing"
             float3 "rtx:sceneDb:ambientLightColor" = (0.1, 0.1, 0.1)
         }
     }

--- a/examples/Google3DTiles/Zurich.usda
+++ b/examples/Google3DTiles/Zurich.usda
@@ -68,7 +68,6 @@
             float3 "rtx:post:tonemap:whitepoint" = (1, 1, 1)
             float3 "rtx:raytracing:inscattering:singleScatteringAlbedo" = (0.9, 0.9, 0.9)
             float3 "rtx:raytracing:inscattering:transmittanceColor" = (0.5, 0.5, 0.5)
-            string "rtx:rendermode" = "PathTracing"
             float3 "rtx:sceneDb:ambientLightColor" = (0.1, 0.1, 0.1)
         }
     }


### PR DESCRIPTION
Once https://github.com/CesiumGS/cesium-omniverse/pull/300 is merged we can set the render mode back to RTX- Real-Time.

RTX - Real-Time|RTX - Interactive
--|--
![rtx-realtime](https://github.com/CesiumGS/cesium-omniverse-samples/assets/915398/d69b6064-3226-47ce-9ed0-93d6178e3de0)|![rtx-interactive](https://github.com/CesiumGS/cesium-omniverse-samples/assets/915398/9820d19e-b3c6-42da-8966-af4d49542d8a)
