### PR TITLE
Remove missing overlay from `RasterOverlays.usda`

### DIFF
--- a/examples/RasterOverlays/RasterOverlays.usda
+++ b/examples/RasterOverlays/RasterOverlays.usda
@@ -353,7 +353,6 @@ def CesiumTilesetPrim "Cesium_World_Terrain"
     int64 cesium:ionAssetId = 1
     prepend rel cesium:ionServerBinding = </CesiumServers/IonOfficial>
     rel cesium:rasterOverlayBinding = [
-        </Cesium_World_Terrain/Bing_Maps_Aerial_imagery>,
         </Cesium_World_Terrain/web_map_tile_service_raster_overlay>,
         </Cesium_World_Terrain/web_map_service_raster_overlay>,
     ]


### PR DESCRIPTION
`Bing_Maps_Aerial_imagery` doesn't actually exist in the scene, and can be removed