### PR TITLE
Use smooth normals for the moon

### DIFF
--- a/examples/Moon/Moon.usda
+++ b/examples/Moon/Moon.usda
@@ -170,6 +170,7 @@ def CesiumTilesetPrim "Cesium_Tileset"
     int64 cesium:ionAssetId = 2684829
     prepend rel cesium:ionServerBinding = </CesiumServers/IonOfficial>
     uniform token cesium:sourceType = "ion"
+    bool cesium:smoothNormals = 1
     float3[] extent = [(-214810290, -450634980, -271685060), (214810290, 103134980, 271685060)]
 }
 


### PR DESCRIPTION
Helps make the surface less tessellated looking. 

Before|After
--|--
![image](https://github.com/user-attachments/assets/5f2845ed-05ef-477e-a110-12b8236806c5)|![image](https://github.com/user-attachments/assets/50bb687b-68a6-4e8f-b2b0-024ff0442e87)
